### PR TITLE
Use colnames(), not names()

### DIFF
--- a/R/lime.R
+++ b/R/lime.R
@@ -59,7 +59,7 @@ lime <- function(x, model, ...) {
 #' @importFrom stats gaussian
 model_permutations <- function(x, y, weights, labels, n_labels, n_features, feature_method) {
   if (!is.null(n_labels)) {
-    labels <- names(y)[order(y[1,], decreasing = TRUE)[seq_len(n_labels)]]
+    labels <- colnames(y)[order(y[1,], decreasing = TRUE)[seq_len(n_labels)]]
   }
   x <- x[, apply(x, 2, var) != 0, drop = FALSE]
   res <- lapply(labels, function(label) {


### PR DESCRIPTION
names() called on a matrix gives dimnames, but you want label names.

y is the matrix output from predict.whatever(type = "prob"), and the colnames has the labels.