### PR TITLE
Fixed bug predicting with xgboost + handling NAs in training data

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -38,10 +38,10 @@ lime.data.frame <- function(x, model, bin_continuous = TRUE, n_bins = 4, quantil
   explainer$bin_cuts <- setNames(lapply(seq_along(x), function(i) {
     if (explainer$feature_type[i] %in% c('numeric', 'integer')) {
       if (quantile_bins) {
-        bins <- quantile(x[[i]], seq(0, 1, length.out = n_bins + 1),na.rm=T)
+        bins <- quantile(x[[i]], seq(0, 1, length.out = n_bins + 1))
         bins[!duplicated(bins)]
       } else {
-        d_range <- range(x[[i]],na.rm=T)
+        d_range <- range(x[[i]])
         seq(d_range[1], d_range[2], length.out = n_bins + 1)
       }
     }

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -38,10 +38,10 @@ lime.data.frame <- function(x, model, bin_continuous = TRUE, n_bins = 4, quantil
   explainer$bin_cuts <- setNames(lapply(seq_along(x), function(i) {
     if (explainer$feature_type[i] %in% c('numeric', 'integer')) {
       if (quantile_bins) {
-        bins <- quantile(x[[i]], seq(0, 1, length.out = n_bins + 1))
+        bins <- quantile(x[[i]], seq(0, 1, length.out = n_bins + 1),na.rm=T)
         bins[!duplicated(bins)]
       } else {
-        d_range <- range(x[[i]])
+        d_range <- range(x[[i]],na.rm=T)
         seq(d_range[1], d_range[2], length.out = n_bins + 1)
       }
     }

--- a/R/models.R
+++ b/R/models.R
@@ -67,7 +67,7 @@ predict_model.WrappedModel <- function(x, newdata, type, ...) {
 }
 predict_model.xgb.Booster <- function(x, newdata, type, ...) {
   if(is.data.frame(newdata)){
-    newdata <- as.matrix(newdata)
+    newdata <- xgb.DMatrix(as.matrix(newdata))
   }
   p <- data.frame(predict(x, newdata = newdata, reshape = TRUE, ...), stringsAsFactors = FALSE)
   if (type == 'raw') {

--- a/R/models.R
+++ b/R/models.R
@@ -66,7 +66,9 @@ predict_model.WrappedModel <- function(x, newdata, type, ...) {
   p
 }
 predict_model.xgb.Booster <- function(x, newdata, type, ...) {
-  newdata <- as.matrix(newdata)
+  if(is.data.frame(newdata)){
+    newdata <- as.matrix(newdata)
+  }
   p <- data.frame(predict(x, newdata = newdata, reshape = TRUE, ...), stringsAsFactors = FALSE)
   if (type == 'raw') {
     names(p) <- 'Response'

--- a/R/models.R
+++ b/R/models.R
@@ -66,6 +66,7 @@ predict_model.WrappedModel <- function(x, newdata, type, ...) {
   p
 }
 predict_model.xgb.Booster <- function(x, newdata, type, ...) {
+  newdata <- as.matrix(newdata)
   p <- data.frame(predict(x, newdata = newdata, reshape = TRUE, ...), stringsAsFactors = FALSE)
   if (type == 'raw') {
     names(p) <- 'Response'


### PR DESCRIPTION
This is my first pull request ever so please bear with me (and let me know) if I am doing something wrong.

This tiny pull request does 2 things: 

1. It fixes what I believe is a bug in predict_model.xgb.Booster which does not transfer the input to a matrix before calling predict (which xgboost requires to do prediction). I simply did this transformation, which makes xgboost work with lime.
2. It allows NA values to be included in the training data when calling lime(). Methods like xgboost can both train and predict even if there are NA values involved, which should then also be OK for lime. The problem in the master was that quantiles and ranges could not be computed when training data passed to lime() included NA-values. This pull request just removes the NA values from this bin/range computations. NOTE: Lime still cannot explain predictions including NA values. I tried to look into this as well, but did find a clean solution. One should probably modifying the input to glmnet() and glm.fit().

Test scripts which shows the working fork and error from the master is given below. Note that the main.package.dir and devel.package.dir needs to be modified appropriately for others to use it. (Please let me know if there are better ways to compare and test my fork vs the master.)

```
# Example running xgboost, handling NA in training data when calling lime()

library(xgboost)
library(devtools)

# Install main and my fork of the lime package
main.package.dir <- "C:\\Users\\jullum\\Documents\\R\\win-library\\3.4"
devel.package.dir <- "C:\\Users\\jullum\\Documents\\R\\win-library\\devel_packages"
withr::with_libpaths(new = main.package.dir, install_github('thomasp85/lime'))
withr::with_libpaths(new = devel.package.dir, install_github('martinju/lime'))

# Defining data 
set.seed(123)
x = matrix(rnorm(100*10),ncol=10)
y = round(runif(100))
data.to.explain <- as.data.frame(head(x))


#### Example running plain xgboost

# Running xgboost
mod = xgboost(data = x,label=y,nrounds = 10,objective = "binary:logistic")

# My fork of the lime package. Works
library(lime, lib.loc = devel.package.dir)
explainer <- lime(x=as.data.frame(x),model=mod)
explanation <- explain(data.to.explain, explainer, labels = 1, n_features = 5)
plot_features(explanation)

# The master version fails
detach("package:lime", unload=TRUE)
library(lime,lib.loc = main.package.dir)
explanation <- explain(data.to.explain, explainer, labels = 1, n_features = 5)
#Error in xgb.DMatrix(newdata, missing = missing) : 
#  xgb.DMatrix does not support construction from list

#### Example runing xgboost with NA values in training

# Modify data
x.NA <- x
x.NA[,1] = ifelse(x.NA[,2] > 0, NA, x.NA[,1]) # introduce random NAs in V1


# Running xgboost
mod.NA = xgboost(data = x.NA,label=y,nrounds = 10,objective = "binary:logistic")

# My fork of the lime package. Works
detach("package:lime", unload=TRUE)
library(lime, lib.loc = devel.package.dir)
explainer <- lime(x=as.data.frame(x.NA),model=mod.NA)
explanation <- explain(data.to.explain, explainer, labels = 1, n_features = 5)
plot_features(explanation)

# The master version fails
detach("package:lime", unload=TRUE)
library(lime,lib.loc = main.package.dir)
explainer <- lime(x=as.data.frame(x.NA),model=mod.NA)
#Error in quantile.default(x[[i]], seq(0, 1, length.out = n_bins + 1)) : 
#  missing values and NaN's not allowed if 'na.rm' is FALSE
```