### PR TITLE
Updating an incorrect call to deprecated Python function attribute "func_name" to the correct attribute name "__name__".

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -234,6 +234,7 @@ model_type.xgb.Booster <- function(x, ...) {
 model_type.lda <- function(x, ...) 'classification'
 #' @export
 model_type.keras.engine.training.Model <- function(x, ...) {
+  print("Entering the target function...")
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }

--- a/R/models.R
+++ b/R/models.R
@@ -237,7 +237,7 @@ model_type.keras.engine.training.Model <- function(x, ...) {
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }
-  if (keras::get_layer(x, index = -1)$activation$__name__ == 'linear') {
+  if (keras::get_layer(x, index = -1)$activation$"__name__" == 'linear') {
     'regression'
   } else {
     'classification'

--- a/R/models.R
+++ b/R/models.R
@@ -234,13 +234,10 @@ model_type.xgb.Booster <- function(x, ...) {
 model_type.lda <- function(x, ...) 'classification'
 #' @export
 model_type.keras.engine.training.Model <- function(x, ...) {
-  print("Entering the target function...")
-  print("Saving the target layer to the global environment...")
-  targetLayer <<- keras::get_layer(x, index = -1)$activation
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }
-  if (keras::get_layer(x, index = -1)$activation$func_name == 'linear') {
+  if (keras::get_layer(x, index = -1)$activation$f.__name__ == 'linear') {
     'regression'
   } else {
     'classification'

--- a/R/models.R
+++ b/R/models.R
@@ -235,6 +235,8 @@ model_type.lda <- function(x, ...) 'classification'
 #' @export
 model_type.keras.engine.training.Model <- function(x, ...) {
   print("Entering the target function...")
+  print("Saving the target layer to the global environment...")
+  targetLayer <<- keras::get_layer(x, index = -1)
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }

--- a/R/models.R
+++ b/R/models.R
@@ -237,7 +237,7 @@ model_type.keras.engine.training.Model <- function(x, ...) {
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }
-  if (keras::get_layer(x, index = -1)$activation$f.__name__ == 'linear') {
+  if (keras::get_layer(x, index = -1)$activation$__name__ == 'linear') {
     'regression'
   } else {
     'classification'

--- a/R/models.R
+++ b/R/models.R
@@ -236,7 +236,7 @@ model_type.lda <- function(x, ...) 'classification'
 model_type.keras.engine.training.Model <- function(x, ...) {
   print("Entering the target function...")
   print("Saving the target layer to the global environment...")
-  targetLayer <<- keras::get_layer(x, index = -1)
+  targetLayer <<- keras::get_layer(x, index = -1)$activation
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }


### PR DESCRIPTION
This PR is a fix in response to this StackOverflow thread:(https://stackoverflow.com/questions/50158290/explain-features-from-my-keras-object-with-lime-r-package/51622735)

The function attribute `func_name` was renamed in python 3+ to `__name__`, which was causing a lime function call to the `keras::get_layer` function to fail.

I've tested the solution in the PR and it works nicely.