### PR TITLE
keras model_type definition fix (AttributeError; func_name doesn't exist for layer activation)

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -237,7 +237,8 @@ model_type.keras.engine.training.Model <- function(x, ...) {
   if (!requireNamespace('keras', quietly = TRUE)) {
     stop('The keras package is required for predicting keras models')
   }
-  if (keras::get_layer(x, index = -1)$activation$func_name == 'linear') {
+  num_layers <- length(x$layers)
+  if (get_config(get_layer(x, index = num_layers))$activation == 'linear') {
     'regression'
   } else {
     'classification'


### PR DESCRIPTION
Removed reference to func_name in keras model_type definition, which was producing an AttributeError.

This issue was also raised [here](https://stackoverflow.com/questions/50158290/explain-features-from-my-keras-object-with-lime-r-package/51622735).

And there is another [PR for this same issue](https://github.com/thomasp85/lime/pull/116), but I'm not sure that fixes it.