### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: R
 cache: packages
-fortran: false
-latex: false
 
 matrix:
   include:
@@ -9,6 +7,8 @@ matrix:
     - r: release
     - r: devel
     - os: osx
+      fortran: false
+      latex: false
 
 addons:
   apt:


### PR DESCRIPTION
To install the `glmnet` dependency on linux you do need Fortran.